### PR TITLE
Styled graph mosaics

### DIFF
--- a/mainapp/templates/base.html
+++ b/mainapp/templates/base.html
@@ -6,8 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{% block title %}{% endblock %}</title>
+    {% block head %}{% endblock %}
   </head>
-  <body>
+  <body style="margin: 0">
     <img src="{% static 'images/sitelogo.png' %}" alt="Logo">
     {% block content %}{% endblock %}
   </body>

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -36,17 +36,24 @@ from .models import Measurement, Metric, User
 
 @login_required
 def index(request):
-    measurements: List[Dict[str, Union[float, str]]] = [
+    measurements_by_metric = [
         {
-            "metric": measurement.metric.name,
-            "value": measurement.value,
-            "date": measurement.date.isoformat(),
+            "metric_id": metric.id,
+            "metric_name": metric.name,
+            "measurements": [
+                {
+                    "value": measurement.value,
+                    "date": measurement.date.isoformat(),
+                }
+                for measurement in Measurement.objects.filter(metric=metric).order_by(
+                    "date"
+                )
+            ],
         }
-        for measurement in Measurement.objects.filter(metric__user=request.user)
+        for metric in Metric.objects.filter(user=request.user).order_by("name")
     ]
     context = {
-        "measurements": measurements,
-        "unique_metrics": sorted(set([d["metric"] for d in measurements])),
+        "measurements_by_metric": measurements_by_metric,
     }
     return render(request, "mainapp/index.html", context)
 

--- a/templates/mainapp/index.html
+++ b/templates/mainapp/index.html
@@ -1,27 +1,38 @@
 {% extends "base.html" %}
-{% block content %}
+{% block head %}
 <script src="https://cdn.jsdelivr.net/npm/vega@5.22.1"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.6.0"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.21.0"></script>
+{% endblock %}
+{% block content %}
 <h1>Dashboard</h1>
-<div id="vis" style="width: 80%"></div>
-{{ measurements|json_script:"measurements" }}
-{{ unique_metrics|json_script:"unique_metrics" }}
-<script>
-  const measurements = JSON.parse(document.getElementById('measurements').textContent);
-  const unique_metrics = JSON.parse(document.getElementById('unique_metrics').textContent);
-  // Assign the specification to a local variable vlSpec.
+<div style="background-color: #f8faf9;">
+{% for measurement in measurements_by_metric %}
+  <div style="margin: 15px; padding: 10px; border-radius: 7px; background-color: white; border: 1px solid lightgray;">
+    <div>{{ measurement.metric_name }}</div>
+    <div id="chart-{{ measurement.metric_id }}" style="width: 100%; height: 300px;"></div>
+  </div>
+  {% with metric_id_str=measurement.metric_id|stringformat:"s" %}
+    {% with script_id="measurement-"|add:metric_id_str %}
+      {{ measurement | json_script:script_id }}
+    {% endwith %}
+  {% endwith %}
+{% endfor %}
+<script type="text/javascript">
   var vlSpec = {
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
     width: "container",
+    height: "container",
+    view: {"stroke": "transparent"}, // Remove background rectangle
+    // This ensures the padding is not added on top of axis padding
+    autosize: {type: 'none'},
+    padding: {right: 30, left: 30, top: 0, bottom: 30},
+
     data: {
-      values: measurements
+      values: null // will be filled later
     },
-    "params": [{
-        "name": "selected_metric",
-        "bind": { "input": "select", "options": unique_metrics },
-        "value": unique_metrics[0],
-      },
+
+    "params": [
       {
         "name": "highlight",
         "select": {
@@ -34,7 +45,6 @@
       }
     ],
     "transform": [
-      { "filter": { "field": "metric", "equal": { "expr": "selected_metric" } } },
       {
         "window": [{
           "field": "value",
@@ -50,28 +60,50 @@
         type: 'ordinal',
         timeUnit: 'dayofyear',
         // https://github.com/d3/d3-time-format#locale_format
-        axis: { title: null, format: '%b %d', labelAngle: -45 },
+        axis: {
+          title: null,
+          format: '%b %d',
+          labelAngle: 0,
+          "labelExpr": "[timeFormat(datum.value, '%d'), (timeFormat(datum.value, '%d') == '01' || datum.index == 0) ? timeFormat(datum.value, '%b') : '']",
+          labelColor: 'gray',
+          domainColor: 'black',
+          tickSize: 3,
+        }
       },
       y: {
         field: 'value',
         type: 'quantitative',
+        axis: {
+          title: false,
+          grid: true,
+          domain: false,
+          ticks: false,
+          offset: 4,
+          format: '.2s', // will show SI units (k, M, G...)
+          orient: 'right',
+          labelColor: 'gray',
+        },
       },
       "tooltip": { "field": "value", "type": "quantitative" }
     },
-    "layer": [{
+    "layer": [
+      // Line
+      {
         "name": "line",
         "mark": { "type": "line", "opacity": 1.0 }
       },
+      // Points
       {
         "name": "points",
         "mark": { "type": "circle" },
         "encoding": {
           "size": {
             "condition": { "param": "highlight", "empty": false, "value": 200 },
-            "value": 50
+            "value": 20 // default value
           }
         }
       },
+      // Moving average
       {
         "name": "moving_average",
         "mark": { "type": "line", "color": "red", "opacity": 0.5 },
@@ -81,9 +113,15 @@
       },
     ],
   };
-
-  // Embed the visualization in the container with id `vis`
-  vegaEmbed('#vis', vlSpec);
+  var values;
+  {% for measurement in measurements_by_metric %}
+    values = JSON.parse(document.getElementById('measurement-{{ measurement.metric_id }}').textContent).measurements;
+    vegaEmbed(
+      '#chart-{{ measurement.metric_id }}',
+      {...vlSpec, data: { values } },
+      {"actions": false}
+    );
+  {% endfor %}
 </script>
 <p>
   <ul>
@@ -91,4 +129,5 @@
     <li><a href="{% url 'metrics' %}">Browse configured metrics</a></li>
   </ul>
 </p>
+</div>
 {% endblock %}


### PR DESCRIPTION
I styled a bit the dashboard view (which is response), inspired by the Google Analytics app.
- cards are introduced (I hardcoded the styles for now)
- y axis is better formatted (shows month only for the first day of the month, or first day of the axis)
- no more dropdown to select metrics: we simply stack them vertically
- SI units are automatically used for y labels (k, M, G...)

This is the mobile view before:
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/1655848/210754421-0c2f0a6e-e68f-4b8e-9219-3f0ed689f118.png">

and after:

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/1655848/210754297-7715f0ac-ee77-4f10-8a42-662588caf9e1.png">
