### PR TITLE
[Grafana] Proof-of-concept for supporting Big Query data source

### DIFF
--- a/integrations/implementations/grafana.py
+++ b/integrations/implementations/grafana.py
@@ -19,10 +19,12 @@ class Grafana(Integration):
                 "type": "string",
                 "format": "password",
                 "required": True,
+                "help_text": "In Grafana, go to Administration > Users and access > Service accounts. Then create new service account with 'viewer' role, and 'Add service account token'"
             },
             "datasource_uid": {
                 "type": "string",
                 "required": True,
+                "help_text": "Find the UID of your datasource by going to the datasource settings in Grafana and looking at the URL. It should look like `https://YOUR_COMPANY.grafana.net/datasources/edit/<UID>`."
             },
             "expression": {
                 "type": "string",

--- a/integrations/implementations/grafana.py
+++ b/integrations/implementations/grafana.py
@@ -16,15 +16,16 @@ class Grafana(Integration):
         "type": "dict",
         "keys": {
             "api_key": {
+                "title": "Service Account Token",
                 "type": "string",
                 "format": "password",
                 "required": True,
-                "help_text": "In Grafana, go to Administration > Users and access > Service accounts. Then create new service account with 'viewer' role, and 'Add service account token'"
+                "help_text": "In Grafana, go to Administration > Users and access > Service accounts. Then create new service account with 'viewer' role, and 'Add service account token'",
             },
             "datasource_uid": {
                 "type": "string",
                 "required": True,
-                "help_text": "Find the UID of your datasource by going to the datasource settings in Grafana and looking at the URL. It should look like `https://YOUR_COMPANY.grafana.net/datasources/edit/<UID>`."
+                "help_text": "Find the UID of your datasource by going to the datasource settings in Grafana and looking at the URL. It should look like `https://YOUR_COMPANY.grafana.net/datasources/edit/<UID>`.",
             },
             "expression": {
                 "type": "string",


### PR DESCRIPTION
Turns out that supporting non-Prometheus data sources requires sending a different payload, which might differ a lot and require different inputs. 

In this PR I got it working, but ideally the extra fields should be dynamically hidden/shown based on selected data source. And it would be even better if the `connection_args` were full fields as well.
It would also be nice to change the "expression" label and help-text depending on selection (PromQL vs SQL).

I did not implement any of that in this PR, as it requires adding JS that is very specific to the Grafana integration and I didn't want to just do that unless it makes sense.

**A completely different approach** is to add a new integration for Big Query directly to Polynomial instead, but that seemed like even more work 😅 

What do you think?

### Preview

![Screenshot 2023-11-23 at 20 42 13](https://github.com/corradio/polynomial/assets/3296643/572abf98-a0b1-427c-a377-fa03f674a887)


Another example of this is the Google Cloud Monitoring data source plugin, which has the following payload:

![Screenshot 2023-11-23 at 20 59 07](https://github.com/corradio/polynomial/assets/3296643/6003e6e0-3231-4ec0-a591-ddb7d56e18ab)

